### PR TITLE
Some cleanup, fix the espresso socket example

### DIFF
--- a/_episodes/06-file-based-calculators.md
+++ b/_episodes/06-file-based-calculators.md
@@ -165,5 +165,5 @@ MOPAC Job: "isopropyl-alcohol.mop" ended normally on Apr  3, 2023, at 21:29.
 {: .output}
 
 > ## Discussion
-> What happens to calc.results when a parameter is changed? When might we prefer to use ``atoms.get_forces()` vs `atoms.calc.results['forces']`?
+> What happens to calc.results when a parameter is changed? When might we prefer to use `atoms.get_forces()` vs `atoms.calc.results['forces']`?
 {: .discussion}

--- a/_episodes/07-external-calculators.md
+++ b/_episodes/07-external-calculators.md
@@ -22,8 +22,8 @@ keypoints:
 
 ### The `quippy` package provides a Python interface to a range of interatomic and tight-binding potentials
 
-- Some calculators have interfaces which are not packaged with ASE, but available elsewhere. 
-- For example, the `quippy` package provides a Python interface to a range of interatomic and tight-binding potentials. 
+- Some calculators have interfaces which are not packaged with ASE, but available elsewhere.
+- For example, the `quippy` package provides a Python interface to a range of interatomic and tight-binding potentials.
 - In this chapter we apply a machine-learning-based potential for Si.
 
 > ## Getting the model and training data
@@ -36,7 +36,7 @@ keypoints:
 > unzip Si_PRX_GAP.zip
 > ~~~
 > {: .bash}
-> 
+>
 {: .callout}
 
 > ## Note
@@ -59,7 +59,7 @@ si.calc = Potential(param_filename='path/to/Si_PRX_GAP/gp_iter6_sparse9k.xml')
 ~~~
 {: .python}
 
-- Third, we calculate an energy; in this case we place this in a `For` loop and apply a random walk to the positions.
+- Third, we calculate an energy; in this case we place this in a `for` loop and apply a random walk to the positions.
 
 ~~~
 energies = []
@@ -76,14 +76,14 @@ ax.set_ylabel('Energy / eV')
 
 ![](../fig/energy_random_walk_plot.png)
 
-- This is a bit more expensive than EMT but still a lot cheaper than density-functional theory! 
+- This is a bit more expensive than EMT but still a lot cheaper than density-functional theory!
 - A lot of work goes into developing a new potential, but with tools like quippy and ASE it is fairly easy for researchers to pick up the resulting model and apply it.
 
-### Quantum Espresso is a suite of programs for electronic structure calculations 
+### Quantum Espresso is a suite of programs for electronic structure calculations
 
 - Here we use the `pw.x` program for DFT calculations with a plane-wave basis set and pseudopotentials.
-- First we need to find our pseudopotentials library and pass this information to the Calculator. 
-- In the virtual environment for these tutorials it can be found here:
+- First we need to find our pseudopotentials library and pass this information to the Calculator.
+- The "Standard Solid-State Pseudopotentials" library is a general-purpose set available in "precision" and "efficiency" versions; for this tutorial we suggest to download the "efficiency" set [from this page](https://www.materialscloud.org/discover/sssp/table/efficiency).
 
 ~~~
 from pathlib import Path
@@ -95,15 +95,18 @@ pseudo_dir = str(
 
 ### Socket interfaces allow more efficient communication and data re-use
 
-- Computing the energy/forces for a series of related structures (e.g. during geometry optimisation), DFT codes typically re-use previously calculated wavefunctions to obtain a good starting estimate. 
+- Computing the energy/forces for a series of related structures (e.g. during geometry optimisation), DFT codes typically re-use previously calculated wavefunctions to obtain a good starting estimate.
 - Using a file-based ASE calculator, each calculation is essentially independent; not only do we miss out on wavefunction re-use, but we incur overhead as the code is "rebooted" (and memory re-allocated, pseudopotentials loaded, etc.).
 - This problem is addressed by codes implementing a socket interface.
-- Here the calculation is initialised once and the code waits to receive a set of atomic positions. It calculates energies and forces, then awaits the next set of positions. 
+- Here the calculation is initialised once and the code waits to receive a set of atomic positions. It calculates energies and forces, then awaits the next set of positions.
 - Typically this is done by the "i-Pi protocol" developed to support calculation of nuclear quantum effects.
 - For the Espresso and FHI-Aims calculators in ASE, this is implemented as wrapper around the main calculator; for VASP and CP2K it works differently.
 
 ~~~
+from ase.calculators.qe import Espresso, EspressoProfile
 from ase.calculators.socketio import SocketIOCalculator
+
+profile = EspressoProfile(['pw.x'])
 
 calc = Espresso(profile=profile,
                 pseudo_dir=pseudo_dir,
@@ -113,7 +116,7 @@ calc = Espresso(profile=profile,
                             'system': {'ecutwfc': 40.}},
                 pseudopotentials={'Si': 'Si.pbe-n-rrkjus_psl.1.0.0.UPF'})
 
-calc = SocketIOCalculator(calc=calc, unixsocket='new-random-walk-socket') 
+calc = SocketIOCalculator(calc=calc, unixsocket='random-walk-socket')
 ~~~
 {: .python}
 

--- a/_episodes/08-calculations-in-parallel.md
+++ b/_episodes/08-calculations-in-parallel.md
@@ -18,7 +18,7 @@ keypoints:
     - "To accelerate our calculation we can parallelise the code over several cores"
     - "`parprint` and `paropen` are provided in ASE as an alternative to `print` and `open`"
     - "Quantum Espresso can also be used for parallel programming with MPI"
-    - "Each ``Calculator` has its own keywords to match the input syntax of the corresponding software code"
+    - "Each `Calculator` has its own keywords to match the input syntax of the corresponding software code"
     - "Once we have setup the calculator we use the same three step process to retrieve a property"
 ---
 
@@ -105,7 +105,7 @@ Initialize ...
 
 ### It is important to check for convergence of the energy with respect to k-point sampling
 
-- Using a `For` loop we can re-run the calculation for a increasing k-point mesh densities.
+- Using a `for` loop we can re-run the calculation for a increasing k-point mesh densities.
     - In this case we pass a dictionary specification that generates a mesh that is shifted off the Gamma-point.
     - We also use the `txt` keyword to direct output to a text file.
 - We collect timing information to understand how increasing mesh density impacts calculation cost. 


### PR DESCRIPTION
Some more small stuff

- cleaning up extra backticks
- using `for` instead of `For` in descriptions; maybe there is a pedagogic reason to prefer "For" but given that the Python syntax is lowercase and we have it in backticks this seems clearer.
- adding a link for SSSP data. If we end up having this preinstalled or in some other setup instructions it can come out again. But I think this will make the tutorial more useful for people _not_ at our workshop, either way.
