### PR TITLE
Reshuffle GPAW/Espresso parallel/socket stuff

### DIFF
--- a/_episodes/07-external-calculators.md
+++ b/_episodes/07-external-calculators.md
@@ -5,13 +5,16 @@ exercises: 20
 questions:
     - "How can I calculate standard properties using an external calculator?"
     - "How can I calculate standard properties using a machine learnt potential?"
-    - "Why are socket calculators more computationally efficient?"
+    - "What is a convenient way to test for k-point convergence?"
 objectives:
     - "Calculate properties using an external calculator and machine learnt potential"
-    - "Calculate properties using a socket interface"
+    - "Perform a convergence test for density-functional theory calculation parameters"
 keypoints:
     - "The `quippy` package provides a Python interface to a range of interatomic and tight-binding potentials"
+    - "GPAW is a package for electronic structure calculations which relies on ASE"
     - "The workflow for external, file-based and built-in calculators is the same"
+    - "It is important to check for convergence of DFT energies with respect to k-point sampling"
+
     - "Quantum Espresso is a suite of programs for electronic structure calculations "
     - "Socket interfaces allow more efficient communication and data re-use"
 ---
@@ -79,49 +82,213 @@ ax.set_ylabel('Energy / eV')
 - This is a bit more expensive than EMT but still a lot cheaper than density-functional theory!
 - A lot of work goes into developing a new potential, but with tools like quippy and ASE it is fairly easy for researchers to pick up the resulting model and apply it.
 
-### Quantum Espresso is a suite of programs for electronic structure calculations
+### "GPAW is a package for electronic structure calculations which relies on ASE"
 
-- Here we use the `pw.x` program for DFT calculations with a plane-wave basis set and pseudopotentials.
-- First we need to find our pseudopotentials library and pass this information to the Calculator.
-- The "Standard Solid-State Pseudopotentials" library is a general-purpose set available in "precision" and "efficiency" versions; for this tutorial we suggest to download the "efficiency" set [from this page](https://www.materialscloud.org/discover/sssp/table/efficiency).
+- GPAW is an electronic structure code implemented as a Python library with C backend.
+- GPAW includes a few command line tools, but is generally always used with ASE.
+- Due to this close relationship many GPAW developers are also ASE developers.
+- GPAW implements the [projector-augmented wave (PAW)](https://wiki.fysik.dtu.dk/gpaw/documentation/introduction_to_paw.html) method which requires atomic "setups" with pseudopotentials.
 
-~~~
-from pathlib import Path
-# Customise if necessary to espresso pseudopotential path
-pseudo_dir = str(
-    Path.home() / 'opt/espresso_sssp/SSSP_1.1.2_PBE_efficiency')
-~~~
-{: .python}
+> ## Getting the data
+> To download the necessary pseudopotential data, run `gpaw install-data ./gpaw-pot/` in the terminal and type `y` when prompted`.
+{: .callout} 
 
-### Socket interfaces allow more efficient communication and data re-use
 
-- Computing the energy/forces for a series of related structures (e.g. during geometry optimisation), DFT codes typically re-use previously calculated wavefunctions to obtain a good starting estimate.
-- Using a file-based ASE calculator, each calculation is essentially independent; not only do we miss out on wavefunction re-use, but we incur overhead as the code is "rebooted" (and memory re-allocated, pseudopotentials loaded, etc.).
-- This problem is addressed by codes implementing a socket interface.
-- Here the calculation is initialised once and the code waits to receive a set of atomic positions. It calculates energies and forces, then awaits the next set of positions.
-- Typically this is done by the "i-Pi protocol" developed to support calculation of nuclear quantum effects.
-- For the Espresso and FHI-Aims calculators in ASE, this is implemented as wrapper around the main calculator; for VASP and CP2K it works differently.
+### Performing a DFT calculation from the Python shell
+
+- To begin with, we run a single-point energy calculation using Kohn-Sham density-functional theory (DFT).
+- First, we import GPAW and create the atoms object
 
 ~~~
-from ase.calculators.qe import Espresso, EspressoProfile
-from ase.calculators.socketio import SocketIOCalculator
+from gpaw import GPAW, PW
 
-profile = EspressoProfile(['pw.x'])
-
-calc = Espresso(profile=profile,
-                pseudo_dir=pseudo_dir,
-                kpts=(2, 2, 2),
-                input_data={'control':  {'tprnfor': True,
-                                         'tstress': True},
-                            'system': {'ecutwfc': 40.}},
-                pseudopotentials={'Si': 'Si.pbe-n-rrkjus_psl.1.0.0.UPF'})
-
-calc = SocketIOCalculator(calc=calc, unixsocket='random-walk-socket')
+atoms = ase.build.bulk('Cu')
 ~~~
 {: .python}
 
-> ## Exercise: Socket random walk calculation
-> Repeat our random-walk energy calculation from the Quippy example using DFT implemented in Quantum Espresso.
->
-> Hint: as this is a DFT calculation and we have only four compute cores, you will need to use a smaller unit cell.
-{: .challenge}
+- Second, we attach GPAW as a calculator
+- We specify a number of parameters:
+    - `xc` sets the exchange-correlation functional
+    - `kpts` sets the Brillouin-zone sampling
+    - `mode` sets the basis set; in this case a 400 eV cutoff plane-wave basis is used.
+- For more information about valid parameters, [see the GPAW docs](https://wiki.fysik.dtu.dk/gpaw/documentation/basic.html#parameters).
+~~~
+atoms.calc = GPAW(xc='PBE', kpts=(3, 3, 3), mode=PW(400))
+~~~
+
+- Finally, we run the calculation and get the result
+
+~~~
+energy = atoms.get_potential_energy()
+~~~
+{: .python}
+
+~~~
+
+  ___ ___ ___ _ _ _  
+ |   |   |_  | | | | 
+ | | | | | . | | | | 
+ |__ |  _|___|_____|  22.8.0
+ |___|_|             
+
+User:   adam@Arctopus
+Date:   Tue Apr  4 11:30:25 2023
+Arch:   x86_64
+Pid:    97252
+CWD:    /home/adam/src/ase-tutorial-2023/development
+Python: 3.10.0
+gpaw:   /home/adam/.conda/envs/user-base/envs/ase-tutorials/lib/python3.10/site-packages/gpaw
+_gpaw:  /home/adam/.conda/envs/user-base/envs/ase-tutorials/lib/python3.10/site-packages/
+        _gpaw.cpython-310-x86_64-linux-gnu.so
+ase:    /home/adam/src/ase/ase (version 3.23.0b1-70eab133b6)
+numpy:  /home/adam/.conda/envs/user-base/envs/ase-tutorials/lib/python3.10/site-packages/numpy (version 1.23.5)
+scipy:  /home/adam/.conda/envs/user-base/envs/ase-tutorials/lib/python3.10/site-packages/scipy (version 1.10.1)
+libxc:  5.2.3
+units:  Angstrom and eV
+cores: 1
+OpenMP: True
+OMP_NUM_THREADS: 1
+
+Input parameters:
+  kpts: [3 3 3]
+  mode: {ecut: 400.0,
+         name: pw}
+  xc: PBE
+
+System changes: positions, numbers, cell, pbc, initial_charges, initial_magmoms 
+
+Initialize ...
+~~~
+{: .output}
+
+### It is important to check for convergence of the energy with respect to k-point sampling
+
+- Using a `for` loop we can re-run the calculation for a increasing k-point mesh densities.
+    - In this case we pass a dictionary specification that generates a mesh that is shifted off the Gamma-point.
+    - We also use the `txt` keyword to direct output to a text file.
+- We collect timing information to understand how increasing mesh density impacts calculation cost. 
+    - The argument `str(k)` is the timer name
+- The number of k-points is retrieved with `get_ibz_k_points()`. Note that `get_bz_k_points()` is not the correct function to use as this does not include reductions made due to system symmetry.
+
+> ## Note
+> This will take a few minutes to run: to see live output, open a terminal and use `tail -f kpts_serial.txt` to see this file grow. When it is finished, you can exit `tail` with ctrl-c.
+{: .callout}
+
+~~~
+from ase.utils.timing import Timer
+
+timer = Timer()
+energies, times, nkpts = [], [], []
+
+for k in range(3,9):
+
+    atoms.calc = GPAW(mode=PW(400), xc='PBE',
+                      kpts={'size': [k, k, k],
+                            'gamma': False},
+                      txt='kpts_serial.txt')
+    timer.start(str(k))
+    energies.append(atoms.get_potential_energy())
+    timer.stop(str(k))
+    times.append(timer.get_time(str(k)))
+    nkpts.append(len(atoms.calc.get_ibz_k_points()))
+~~~
+{: .python}
+
+~~~
+Timing:                              incl.     excl.
+-----------------------------------------------------------
+Hamiltonian:                         0.096     0.000   0.0% |
+ Atomic:                             0.088     0.001   0.0% |
+  XC Correction:                     0.087     0.087   0.8% |
+ Calculate atomic Hamiltonians:      0.001     0.001   0.0% |
+ Communicate:                        0.000     0.000   0.0% |
+ Initialize Hamiltonian:             0.000     0.000   0.0% |
+ Poisson:                            0.000     0.000   0.0% |
+ XC 3D grid:                         0.007     0.007   0.1% |
+LCAO initialization:                 0.344     0.082   0.7% |
+ LCAO eigensolver:                   0.147     0.000   0.0% |
+  Calculate projections:             0.000     0.000   0.0% |
+  DenseAtomicCorrection:             0.000     0.000   0.0% |
+  Distribute overlap matrix:         0.000     0.000   0.0% |
+  Orbital Layouts:                   0.001     0.001   0.0% |
+  Potential matrix:                  0.144     0.144   1.3% ||
+  Sum over cells:                    0.001     0.001   0.0% |
+ LCAO to grid:                       0.018     0.018   0.2% |
+ Set positions (LCAO WFS):           0.097     0.012   0.1% |
+  Basic WFS set positions:           0.002     0.002   0.0% |
+  Basis functions set positions:     0.000     0.000   0.0% |
+  P tci:                             0.014     0.014   0.1% |
+  ST tci:                            0.039     0.039   0.3% |
+  mktci:                             0.030     0.030   0.3% |
+PWDescriptor:                        0.017     0.017   0.2% |
+SCF-cycle:                           1.907     0.101   0.9% |
+ Davidson:                           0.459     0.152   1.3% ||
+  Apply H:                           0.033     0.027   0.2% |
+   HMM T:                            0.006     0.006   0.1% |
+  Subspace diag:                     0.076     0.004   0.0% |
+   calc_h_matrix:                    0.056     0.023   0.2% |
+    Apply H:                         0.034     0.027   0.2% |
+     HMM T:                          0.006     0.006   0.1% |
+   diagonalize:                      0.009     0.009   0.1% |
+   rotate_psi:                       0.006     0.006   0.1% |
+  calc. matrices:                    0.160     0.091   0.8% |
+   Apply H:                          0.069     0.056   0.5% |
+    HMM T:                           0.012     0.012   0.1% |
+  diagonalize:                       0.023     0.023   0.2% |
+  rotate_psi:                        0.014     0.014   0.1% |
+ Density:                            0.191     0.000   0.0% |
+  Atomic density matrices:           0.019     0.019   0.2% |
+  Mix:                               0.064     0.064   0.6% |
+  Multipole moments:                 0.001     0.001   0.0% |
+  Pseudo density:                    0.106     0.015   0.1% |
+   Symmetrize density:               0.091     0.091   0.8% |
+ Hamiltonian:                        1.152     0.004   0.0% |
+  Atomic:                            0.952     0.015   0.1% |
+   XC Correction:                    0.937     0.937   8.2% |--|
+  Calculate atomic Hamiltonians:     0.006     0.006   0.1% |
+  Communicate:                       0.000     0.000   0.0% |
+  Poisson:                           0.002     0.002   0.0% |
+  XC 3D grid:                        0.189     0.189   1.7% ||
+ Orthonormalize:                     0.003     0.000   0.0% |
+  calc_s_matrix:                     0.001     0.001   0.0% |
+  inverse-cholesky:                  0.000     0.000   0.0% |
+  projections:                       0.001     0.001   0.0% |
+  rotate_psi_s:                      0.000     0.000   0.0% |
+Set symmetry:                        0.025     0.025   0.2% |
+Other:                               8.970     8.970  79.0% |-------------------------------|
+-----------------------------------------------------------
+Total:                                        11.359 100.0%
+
+Memory usage: 390.56 MiB
+Date: Tue Apr  4 11:30:36 2023
+~~~
+{: .output}
+
+- Finally, we plot the results using a matplotlib figure with multiple subplots.
+
+~~~
+fig, axes = plt.subplots(nrows=2, sharex=True)
+axes[0].plot(nkpts, energies, 'o-')
+axes[0].set_ylabel('energy / eV') 
+axes[1].plot(nkpts, times, 'o-')
+axes[1].set_ylabel('Calculation time / s')
+axes[1].set_ylim([0, None])
+axes[1].set_xlabel('number of k-points')
+~~~
+{: .python}
+
+<img src="../fig/convergence_kpoint.png" alt="plot of energy convergence with respect to number of k-points" width="600">
+
+- We find that the computational cost per k-point is roughly linear, but the energy convergence is relatively slow. 
+
+~~~
+change_in_energies = np.diff(energies) 
+print(change_in_energies)
+~~~
+{: .python}
+
+~~~
+[ 0.04294983 -0.05835439  0.00339695 -0.00389174 -0.00460936]
+~~~
+{: .output}
+

--- a/_episodes/08-calculations-in-parallel.md
+++ b/_episodes/08-calculations-in-parallel.md
@@ -3,18 +3,15 @@ title: "Calculations in parallel"
 teaching: 25
 exercises: 20
 questions:
-    - "What can I use to Density Functional Theory calculations?"
-    - "What is an efficient way to test for k-point convergence?"
     - "Is it possible to run calculations in parallel using ASE?"
+    - "How can I store useful results from a script?"
     - "How can I measure the speed-up achieved?"
 objectives:
-    - "Run a DFT calculation and check for the convergence of energy with respect to the number of k-points"
     - "Use the GPAW Python interpreter to run a DFT calculation across multiple cores and measure the speed-up achieved"
+    - "Save the relevant data in a JSON file for further analysis"
     - "Use the Quantum Espresso code to run a DFT calculation across multiple cores"
 keypoints:
     - "GPAW includes a special Python interpreter for parallel calculations"
-    - "The workflow for single core GPAW calculations is the same as that for built-in calculators"
-    - "It is important to check for convergence of the energy with respect to k-point sampling"
     - "To accelerate our calculation we can parallelise the code over several cores"
     - "`parprint` and `paropen` are provided in ASE as an alternative to `print` and `open`"
     - "Quantum Espresso can also be used for parallel programming with MPI"
@@ -23,226 +20,21 @@ keypoints:
 ---
 
 > ## Code connection
-> In this episode we explore [GPAW](https://wiki.fysik.dtu.dk/gpaw/) and [Quantum Espresso](https://www.quantum-espresso.org/), which are external electronic structure codes that can be used for parallel calculations in ASE.
+> In this episode we perform parallel calculations with [GPAW](https://wiki.fysik.dtu.dk/gpaw/) and [Quantum Espresso](https://www.quantum-espresso.org/).
 {: .callout}
 
-### GPAW includes a special Python interpreter for parallel calculations
-
-- GPAW is a bit special! It is an electronic structure code implemented as a Python library with C backend.
-- GPAW development is closely related to ASE development.
-- The difference between GPAW and other external Python calculators is that it includes a special Python interpreter for parallel calculations.
-
-> ## Getting the data
-> To download the necessary pseudopotential data, run `gpaw install-data ./gpaw-pot/` in the terminal and type `y` when prompted`.
-{: .callout} 
-
-
-### For serial GPAW calculations we use the standard procedure 
-
-- To begin with, we run a single-point energy calculation using Kohn-Sham density-functional theory (DFT).
-- First, we import GPAW and create the atoms object
-
-~~~
-from gpaw import GPAW, PW
-
-atoms = ase.build.bulk('Cu')
-~~~
-{: .python}
-
-- Second, we attach GPAW as a calculator
-- We specify a number of parameters:
-    - `xc` sets the exchange-correlation functional
-    - `kpts` sets the Brillouin-zone sampling
-    - `mode` sets the basis set; in this case a 400 eV cutoff plane-wave basis is used.
-- For more information about valid parameters, [see the GPAW docs](https://wiki.fysik.dtu.dk/gpaw/documentation/basic.html#parameters).
-~~~
-atoms.calc = GPAW(xc='PBE', kpts=(3, 3, 3), mode=PW(400))
-~~~
-
-- Finally, we run the calculation and get the result
-
-~~~
-energy = atoms.get_potential_energy()
-~~~
-{: .python}
-
-~~~
-
-  ___ ___ ___ _ _ _  
- |   |   |_  | | | | 
- | | | | | . | | | | 
- |__ |  _|___|_____|  22.8.0
- |___|_|             
-
-User:   adam@Arctopus
-Date:   Tue Apr  4 11:30:25 2023
-Arch:   x86_64
-Pid:    97252
-CWD:    /home/adam/src/ase-tutorial-2023/development
-Python: 3.10.0
-gpaw:   /home/adam/.conda/envs/user-base/envs/ase-tutorials/lib/python3.10/site-packages/gpaw
-_gpaw:  /home/adam/.conda/envs/user-base/envs/ase-tutorials/lib/python3.10/site-packages/
-        _gpaw.cpython-310-x86_64-linux-gnu.so
-ase:    /home/adam/src/ase/ase (version 3.23.0b1-70eab133b6)
-numpy:  /home/adam/.conda/envs/user-base/envs/ase-tutorials/lib/python3.10/site-packages/numpy (version 1.23.5)
-scipy:  /home/adam/.conda/envs/user-base/envs/ase-tutorials/lib/python3.10/site-packages/scipy (version 1.10.1)
-libxc:  5.2.3
-units:  Angstrom and eV
-cores: 1
-OpenMP: True
-OMP_NUM_THREADS: 1
-
-Input parameters:
-  kpts: [3 3 3]
-  mode: {ecut: 400.0,
-         name: pw}
-  xc: PBE
-
-System changes: positions, numbers, cell, pbc, initial_charges, initial_magmoms 
-
-Initialize ...
-~~~
-{: .output}
-
-### It is important to check for convergence of the energy with respect to k-point sampling
-
-- Using a `for` loop we can re-run the calculation for a increasing k-point mesh densities.
-    - In this case we pass a dictionary specification that generates a mesh that is shifted off the Gamma-point.
-    - We also use the `txt` keyword to direct output to a text file.
-- We collect timing information to understand how increasing mesh density impacts calculation cost. 
-    - The argument `str(k)` is the timer name
-- The number of k-points is retrieved with `get_ibz_k_points()`. Note that `get_bz_k_points()` is not the correct function to use as this does not include reductions made due to system symmetry.
-
-> ## Note
-> This will take a few minutes to run: to see live output, open a terminal and use `tail -f kpts_serial.txt` to see this file grow. When it is finished, you can exit `tail` with ctrl-c.
-{: .callout}
-
-~~~
-from ase.utils.timing import Timer
-
-timer = Timer()
-energies, times, nkpts = [], [], []
-
-for k in range(3,9):
-
-    atoms.calc = GPAW(mode=PW(400), xc='PBE',
-                      kpts={'size': [k, k, k],
-                            'gamma': False},
-                      txt='kpts_serial.txt')
-    timer.start(str(k))
-    energies.append(atoms.get_potential_energy())
-    timer.stop(str(k))
-    times.append(timer.get_time(str(k)))
-    nkpts.append(len(atoms.calc.get_ibz_k_points()))
-~~~
-{: .python}
-
-~~~
-Timing:                              incl.     excl.
------------------------------------------------------------
-Hamiltonian:                         0.096     0.000   0.0% |
- Atomic:                             0.088     0.001   0.0% |
-  XC Correction:                     0.087     0.087   0.8% |
- Calculate atomic Hamiltonians:      0.001     0.001   0.0% |
- Communicate:                        0.000     0.000   0.0% |
- Initialize Hamiltonian:             0.000     0.000   0.0% |
- Poisson:                            0.000     0.000   0.0% |
- XC 3D grid:                         0.007     0.007   0.1% |
-LCAO initialization:                 0.344     0.082   0.7% |
- LCAO eigensolver:                   0.147     0.000   0.0% |
-  Calculate projections:             0.000     0.000   0.0% |
-  DenseAtomicCorrection:             0.000     0.000   0.0% |
-  Distribute overlap matrix:         0.000     0.000   0.0% |
-  Orbital Layouts:                   0.001     0.001   0.0% |
-  Potential matrix:                  0.144     0.144   1.3% ||
-  Sum over cells:                    0.001     0.001   0.0% |
- LCAO to grid:                       0.018     0.018   0.2% |
- Set positions (LCAO WFS):           0.097     0.012   0.1% |
-  Basic WFS set positions:           0.002     0.002   0.0% |
-  Basis functions set positions:     0.000     0.000   0.0% |
-  P tci:                             0.014     0.014   0.1% |
-  ST tci:                            0.039     0.039   0.3% |
-  mktci:                             0.030     0.030   0.3% |
-PWDescriptor:                        0.017     0.017   0.2% |
-SCF-cycle:                           1.907     0.101   0.9% |
- Davidson:                           0.459     0.152   1.3% ||
-  Apply H:                           0.033     0.027   0.2% |
-   HMM T:                            0.006     0.006   0.1% |
-  Subspace diag:                     0.076     0.004   0.0% |
-   calc_h_matrix:                    0.056     0.023   0.2% |
-    Apply H:                         0.034     0.027   0.2% |
-     HMM T:                          0.006     0.006   0.1% |
-   diagonalize:                      0.009     0.009   0.1% |
-   rotate_psi:                       0.006     0.006   0.1% |
-  calc. matrices:                    0.160     0.091   0.8% |
-   Apply H:                          0.069     0.056   0.5% |
-    HMM T:                           0.012     0.012   0.1% |
-  diagonalize:                       0.023     0.023   0.2% |
-  rotate_psi:                        0.014     0.014   0.1% |
- Density:                            0.191     0.000   0.0% |
-  Atomic density matrices:           0.019     0.019   0.2% |
-  Mix:                               0.064     0.064   0.6% |
-  Multipole moments:                 0.001     0.001   0.0% |
-  Pseudo density:                    0.106     0.015   0.1% |
-   Symmetrize density:               0.091     0.091   0.8% |
- Hamiltonian:                        1.152     0.004   0.0% |
-  Atomic:                            0.952     0.015   0.1% |
-   XC Correction:                    0.937     0.937   8.2% |--|
-  Calculate atomic Hamiltonians:     0.006     0.006   0.1% |
-  Communicate:                       0.000     0.000   0.0% |
-  Poisson:                           0.002     0.002   0.0% |
-  XC 3D grid:                        0.189     0.189   1.7% ||
- Orthonormalize:                     0.003     0.000   0.0% |
-  calc_s_matrix:                     0.001     0.001   0.0% |
-  inverse-cholesky:                  0.000     0.000   0.0% |
-  projections:                       0.001     0.001   0.0% |
-  rotate_psi_s:                      0.000     0.000   0.0% |
-Set symmetry:                        0.025     0.025   0.2% |
-Other:                               8.970     8.970  79.0% |-------------------------------|
------------------------------------------------------------
-Total:                                        11.359 100.0%
-
-Memory usage: 390.56 MiB
-Date: Tue Apr  4 11:30:36 2023
-~~~
-{: .output}
-
-- Finally, we plot the results using a matplotlib figure with multiple subplots.
-
-~~~
-fig, axes = plt.subplots(nrows=2, sharex=True)
-axes[0].plot(nkpts, energies, 'o-')
-axes[0].set_ylabel('energy / eV') 
-axes[1].plot(nkpts, times, 'o-')
-axes[1].set_ylabel('Calculation time / s')
-axes[1].set_ylim([0, None])
-axes[1].set_xlabel('number of k-points')
-~~~
-{: .python}
-
-<img src="../fig/convergence_kpoint.png" alt="plot of energy convergence with respect to number of k-points" width="600">
-
-- We find that the computational cost per k-point is roughly linear, but the energy convergence is relatively slow. 
-
-~~~
-change_in_energies = np.diff(energies) 
-print(change_in_energies)
-~~~
-{: .python}
-
-~~~
-[ 0.04294983 -0.05835439  0.00339695 -0.00389174 -0.00460936]
-~~~
-{: .output}
 
 ### To accelerate our calculation we can parallelise the code over several cores
+
+- In the previous tutorial we performed DFT calculations with GPAW using one CPU core.
+- This approach will be too slow for many useful calculations.
 
 > ## Parallel programming systems
 > There are several schemes for parallelising code. The two most common are [MPI](https://en.wikipedia.org/wiki/Message_Passing_Interface) and [OpenMP](https://en.wikipedia.org/wiki/OpenMP), with the optimum choice dependent on both the code and the hardware being used (for example, memory or CPU architecture, number of cores per node, network speed). Increasingly, electronic structure codes enable a hybrid of both approaches.
 {: .callout}
 
 - To split our code over several MPI processes we will use a special GPAW Python interpreter.
-- We will use this to tun a script file named "kpts_parallel.py". This is very similar to the code above, except we will:
+- We will use this to run a script file named "kpts_parallel.py". This is very similar to the code we used before, except we will:
     - use the `parallel` keyword to switch on k-point parallelisation.
     - write a dictionary of the results to a json file.
 
@@ -251,6 +43,10 @@ print(change_in_energies)
 - Commands such as `print` or `open` can cause data corruption when multiple processes try to write to the same file. 
 - `parprint` and `paropen` are provided in ASE to handle these common cases
 - For other scenarios it may be necessary to use logic with `ase.parallel.world`. For more information see the relevant [GPAW docs](https://wiki.fysik.dtu.dk/gpaw/documentation/parallel_runs/parallel_runs.html) and [ASE docs](https://wiki.fysik.dtu.dk/ase/ase/parallel.html)
+
+> ## Do not run this code in your notebook!
+> The next code block should go into a new script file named "kpts_parallel.py"
+{: .callout}
 
 ~~~
 from gpaw import GPAW, PW
@@ -296,7 +92,9 @@ gpaw -P 4 python kpts_parallel.py
 ~~~
 {: .bash}
 
-- Finally, we can plot the results.
+- Finally, we can plot the results back in our main Python session.
+- (This assumes the `energies` and `times` variables are still available from the previous tutorial. If not, you will need to run the serial example again!)
+- The new energies and times are read from a JSON file. This is a useful format for saving and loading simple Python dictionary data, and is interoperable with many programming languages and software tools.
 
 ~~~
 import json
@@ -408,6 +206,4 @@ cat espresso.in
 >
 > Hint: you will need to calculate this property at several cutoff energies. Use Python functions and iteration constructs to avoid too much repetition.
 {: .challenge}
-
-
 

--- a/_episodes/11-local-optimisation.md
+++ b/_episodes/11-local-optimisation.md
@@ -417,7 +417,6 @@ Stress:
 > ## Exercise: Fixing the symmetry
 > A very useful constraint is the [FixSymmetry](https://wiki.fysik.dtu.dk/ase/ase/constraints.html#the-fixsymmetry-class) class.
 > Find a geometry file for a high-symmetry crystal structure. With a Calculator of your choice, perform a geometry optimization of the lattice vectors and atomic positions while fixing the symmetry.
-> If compute power allows, you may choose to use DFT.
+> If compute power allows, you may choose to use DFT. If using Quantum Espresso, you may find it helpful to look at the SocketIOCalculator setup in the [extra content section](../13-extras/index.html).
 {: .challenge}
-
 

--- a/_episodes/12-what-next.md
+++ b/_episodes/12-what-next.md
@@ -20,8 +20,10 @@ keypoints:
 
 ### There are many features of ASE we have not yet explored
 
+- If you still have time, there is a bit of extra material on the [next page](../13-extras/index.html)
 - There are some nice resources which compliment what we have covered in this tutorial:
 	- [ASE website tutorials](https://wiki.fysik.dtu.dk/ase/tutorials/tutorials.html)
+      - The [ASE database](https://wiki.fysik.dtu.dk/ase/tutorials/tut06_database/database.html) is especially relevant to this workshop, providing ways to share data and manage large sets of automated calculations.
 	- [CAMD summer school (GPAW) tutorials](https://wiki.fysik.dtu.dk/gpaw/summerschools/summerschool22/summerschool22.html)
     - [The main GPAW tutorials](https://wiki.fysik.dtu.dk/gpaw/tutorialsexercises/tutorialsexercises.html)
 	- Some tutorials are still accessible from the 2019 workshop at Chalmers University of Technology:

--- a/_episodes/13-extras.md
+++ b/_episodes/13-extras.md
@@ -1,0 +1,52 @@
+---
+title: "Extra topics"
+questions:
+    - "Why are socket calculators more computationally efficient?"
+objectives:
+    - "Calculate properties using a socket interface"
+keypoints:
+    - "Socket interfaces allow more efficient communication and data re-use"
+---
+
+### Socket interfaces allow more efficient communication and data re-use
+
+- Computing the energy/forces for a series of related structures (e.g. during geometry optimisation), DFT codes typically re-use previously calculated wavefunctions to obtain a good starting estimate.
+- Using a file-based ASE calculator, each calculation is essentially independent; not only do we miss out on wavefunction re-use, but we incur overhead as the code is "rebooted" (and memory re-allocated, pseudopotentials loaded, etc.).
+- This problem is addressed by codes implementing a socket interface.
+- Here the calculation is initialised once and the code waits to receive a set of atomic positions. It calculates energies and forces, then awaits the next set of positions.
+- Typically this is done by the "i-Pi protocol" developed to support calculation of nuclear quantum effects.
+- For the Espresso and FHI-Aims calculators in ASE, this is implemented as wrapper around the main calculator; for VASP and CP2K it works differently.
+
+~~~
+from ase.calculators.qe import Espresso, EspressoProfile
+from ase.calculators.socketio import SocketIOCalculator
+
+profile = EspressoProfile(['pw.x'])
+
+calc = Espresso(profile=profile,
+                pseudo_dir=pseudo_dir,
+                kpts=(2, 2, 2),
+                input_data={'control':  {'tprnfor': True,
+                                         'tstress': True},
+                            'system': {'ecutwfc': 40.}},
+                pseudopotentials={'Si': 'Si.pbe-n-rrkjus_psl.1.0.0.UPF'})
+
+calc = SocketIOCalculator(calc=calc, unixsocket='random-walk-socket')
+~~~
+{: .python}
+
+> ## Quantum Espresso setup
+> The Quantum Espresso calculator was introduced in [a previous tutorial](../08-calculations-in-parallel/index.html),
+> if you haven't done this tutorial yet, look there for some setup information.
+{: .callout}
+
+> ## Exercise: Socket random walk calculation
+> Repeat our random-walk energy calculation from the [Quippy example](../07-external-calculations/index.html) using DFT implemented in Quantum Espresso.
+>
+> Hint: as this is a DFT calculation and we have only four compute cores, you will need to use a smaller unit cell.
+{: .challenge}
+
+> ## Exercise: Geometry optimisation
+> For a small unit cell of your choice, try performing geometry optimization with the QuasiNewton optimizer.
+> How does the performance compare between using Espresso as a FileIOCalculator and as a SocketIOCalculator?
+{: .challenge}


### PR DESCRIPTION
Here is an attempt to refactor things into tidier thematic chunks, while introducing things gently. I think it's an improvement, but it might need an extra proof-read once merged to check there isn't still something appearing out of sequence!

- Move Espresso sockets to "extra" material as it doesn't quite fit the lesson structure and currently appears before Espresso is properly introduced

- Instead introduce serial / in-notebook GPAW as the DFT calculator for "External calculators"

- Then the parallel tutorial is more focused on parallelism

- Highlight use of JSON as an interoperability-friendly choice for dumping data from script run

- Plug ASE DB tutorial as it's looking like there won't be time to add anything on this

@lucydot I have probably messed up the time estimates in the process, how should that be rectified?